### PR TITLE
Fix double boxing of Script.Call

### DIFF
--- a/src/MoonSharp.Interpreter/Script.cs
+++ b/src/MoonSharp.Interpreter/Script.cs
@@ -584,8 +584,19 @@ namespace MoonSharp.Interpreter
 		{
 			return Call(DynValue.FromObject(this, function), args);
 		}
-		
-		
+
+		/// <summary>
+		/// Calls the specified function.
+		/// </summary>
+		/// <param name="function">The Lua/MoonSharp function to be called </param>
+		/// <param name="args">The arguments to pass to the function.</param>
+		/// <returns></returns>
+		/// <exception cref="System.ArgumentException">Thrown if function is not of DataType.Function</exception>
+		public DynValue Call(object function, params DynValue[] args)
+		{
+			return Call(DynValue.FromObject(this, function), args);
+		}
+
 		public Task<DynValue> CallAsync(DynValue function, params object[] args)
 		{
 			DynValue[] dargs = new DynValue[args.Length];

--- a/src/MoonSharp.Tests/EndToEnd/FunctionTests.cs
+++ b/src/MoonSharp.Tests/EndToEnd/FunctionTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace MoonSharp.Interpreter.Tests.EndToEnd
+{
+    [TestFixture]
+    public class FunctionTests
+    {
+        DynValue ListFilter(Script sc, CallbackArguments args)
+        {
+            Table tbl = new Table(sc);
+            DynValue dv = DynValue.NewTable(tbl);
+
+            Table toFilter = args[0].Table;
+            Closure filterFn = args[1].Function;
+
+            foreach (TablePair pair in toFilter.Pairs)
+            {
+                DynValue valPair = pair.Value;
+                DynValue check = filterFn.Call(valPair);
+
+                if (check.Boolean)
+                {
+                    tbl.Append(valPair);
+                }
+            }
+
+            return dv;
+        }
+
+        [Test]
+        public void ListFilter()
+        {
+            string script = @"
+                arr = list_filter({10, 20, 30}, function (x) return x >= 20 end)
+                return arr[1]
+            ";
+
+            var sc = new Script();
+            sc.Globals["list_filter"] = (Func<Script, CallbackArguments, DynValue>)ListFilter;
+            var x = sc.DoString(script);
+
+            Assert.AreEqual(20, x.Number);
+        }
+    }
+}


### PR DESCRIPTION
Unpatched this would call `Script.Call(object function, params object[] args)` boxing `Dynvalue[]` to `object[]` and method `Script.DynValue Call(DynValue function, params DynValue[] args)` would hence unbox it twice as `DynValue[][]`